### PR TITLE
Prefixable resources

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,7 @@
     "semi-spacing": "error",
     "strict": "error",
 
-    "node/no-unsupported-features": ["error", {"version": 4}],
+    "node/no-unsupported-features": ["error", {"version": 6}],
     "node/no-missing-require": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "scripts": {
     "pretest": "eslint test index.js",
-    "test": "validate-template test/github.test.js && validate-template test/passthrough.test.js",
+    "test": "./test/run.sh",
     "example": "build-template test/github.test.js"
   },
   "devDependencies": {

--- a/test/github-named.test.js
+++ b/test/github-named.test.js
@@ -51,6 +51,6 @@ const myTemplate = {
   }
 };
 
-const webhook = buildWebhook('MyLambda');
+const webhook = buildWebhook('MyLambda', 'MyPrefix');
 
 module.exports = cf.merge(myTemplate, webhook);

--- a/test/passthrough-named.test.js
+++ b/test/passthrough-named.test.js
@@ -1,20 +1,31 @@
 'use strict';
 
 const cf = require('@mapbox/cloudfriend');
-const buildWebhook = require('..').github;
+const buildWebhook = require('..').passthrough;
 
 const myTemplate = {
   Resources: {
+    MyLogs: {
+      Type: 'AWS::Logs::LogGroup',
+      Properties: {
+        LogGroupName: cf.sub('/aws/lambda/${AWS::StackName}'),
+        RetentionInDays: 14
+      }
+    },
     MyLambda: {
       Type: 'AWS::Lambda::Function',
       Properties: {
         Code: {
-          S3Bucket: 'my-bucket',
-          S3Key: 'my-code.zip'
+          ZipFile: cf.join('\n', [
+            'module.exports.handler = (event, context, callback) => {',
+            '  console.log(event);',
+            '  callback();',
+            '};'
+          ])
         },
-        FunctionName: 'MyGithubWebhook',
+        FunctionName: cf.stackName,
         Handler: 'index.handler',
-        MemorySize: 256,
+        MemorySize: 128,
         Runtime: 'nodejs6.10',
         Timeout: 300,
         Role: cf.getAtt('LambdaRole', 'Arn')
@@ -40,7 +51,7 @@ const myTemplate = {
                 {
                   Effect: 'Allow',
                   Action: 'logs:*',
-                  Resource: 'arn:aws:logs:*'
+                  Resource: cf.getAtt('MyLogs', 'Arn')
                 }
               ]
             }
@@ -51,6 +62,6 @@ const myTemplate = {
   }
 };
 
-const webhook = buildWebhook('MyLambda');
+const webhook = buildWebhook('MyLambda', 'MyPrefix');
 
 module.exports = cf.merge(myTemplate, webhook);

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+validate="./node_modules/.bin/validate-template"
+
+echo "github:"
+${validate} test/github.test.js
+
+echo "github-named:"
+${validate} test/github-named.test.js
+
+echo "passthrough:"
+${validate} test/passthrough.test.js
+
+echo "passthrough-named:"
+${validate} test/passthrough-named.test.js


### PR DESCRIPTION
- [added] Can specify a "prefix" if you are going to have multiple webhooks in a template. Fixes #7 
- [breaking] Drops support for node 4
- [breaking] Module doesn't export the github builder directly. Instead, `.github()` is a function exported by the module. `.passthrough()` is unchanged.

  ```js
  const hookshot = require('@mapbox/hookshot');
  // it was
  const githubResources = hookshot('MyLambda');
  // but now
  const githubResources = hookshot.github('MyLambda');
  ```

cc @emilymdubois @davidtheclark @vincentsarago 
  