### PR TITLE
Be explicit about allowed headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ const OptionsMethod = (prefix) => ({
         {
           StatusCode: 200,
           ResponseParameters: {
-            'method.response.header.Access-Control-Allow-Headers': '\'*\'',
+            'method.response.header.Access-Control-Allow-Headers': '\'Content-Type\'',
             'method.response.header.Access-Control-Allow-Methods': '\'POST,OPTIONS\'',
             'method.response.header.Access-Control-Allow-Origin': '\'*\''
           },


### PR DESCRIPTION
refs #16 

This is an interim fix while I try to find a way to mirror the request's access-control-request-headers values into the OPTIONS response.